### PR TITLE
Uses a Collection-based Iterator Ancestor

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,9 @@
     "minimum-stability": "dev",
     "require": {
         "php": "^5.3 | ^7.0",
-        "dhii/modular-interface": "dev-task/initial-interface"
+        "rebelcode/module-interface": "dev-master",
+        "dhii/modular-interface": "dev-task/initial-interface",
+        "dhii/collections-abstract-base": "dev-wip/refactor"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",
@@ -28,5 +30,11 @@
     "scripts": {
         "test": "phpunit",
         "csfix": "php-cs-fixer fix -vvv"
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/RebelCodecom/module-interface"
+        }
+    ]
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,47 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "343fec9e450a5d60b273674cc82f9c6f",
+    "content-hash": "9039bb500fcfbb304648095337eeee2b",
     "packages": [
+        {
+            "name": "dhii/collections-abstract-base",
+            "version": "dev-wip/refactor",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dhii/collections-abstract-base.git",
+                "reference": "70afd75f6d35c083d06c42c8e47497f5fb7747cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dhii/collections-abstract-base/zipball/70afd75f6d35c083d06c42c8e47497f5fb7747cb",
+                "reference": "70afd75f6d35c083d06c42c8e47497f5fb7747cb",
+                "shasum": ""
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "dev-master",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Dhii\\Collection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Dhii Team",
+                    "email": "development@dhii.co"
+                }
+            ],
+            "description": "Collection base classes that do not depend on other non-collection packages, on which there is a dependency of other collection packages that depend on this package. This is done to avoid circular reference in the collection toolchain",
+            "time": "2016-10-17 07:50:40"
+        },
         {
             "name": "dhii/data-key-value-aware-interface",
             "version": "v0.1",
@@ -54,12 +93,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Dhii/modular-interface.git",
-                "reference": "0851c7efe5a40dea124e4d2202103920fa10bb70"
+                "reference": "38d369b22c4caa69ad9484dd1e940c359a458d79"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Dhii/modular-interface/zipball/0851c7efe5a40dea124e4d2202103920fa10bb70",
-                "reference": "0851c7efe5a40dea124e4d2202103920fa10bb70",
+                "url": "https://api.github.com/repos/Dhii/modular-interface/zipball/38d369b22c4caa69ad9484dd1e940c359a458d79",
+                "reference": "38d369b22c4caa69ad9484dd1e940c359a458d79",
                 "shasum": ""
             },
             "require": {
@@ -89,7 +128,61 @@
                 }
             ],
             "description": "Interfaces for modular systems.",
-            "time": "2017-06-12 14:06:05"
+            "time": "2017-06-12 16:39:20"
+        },
+        {
+            "name": "rebelcode/module-interface",
+            "version": "dev-master",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/RebelCodecom/module-interface.git",
+                "reference": "ce8432ad90d4be92b4a195e588fb863bc2046c20"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/RebelCodecom/module-interface/zipball/ce8432ad90d4be92b4a195e588fb863bc2046c20",
+                "reference": "ce8432ad90d4be92b4a195e588fb863bc2046c20",
+                "shasum": ""
+            },
+            "require": {
+                "dhii/modular-interface": "dev-task/initial-interface",
+                "php": "^5.3 | ^7.0"
+            },
+            "require-dev": {
+                "codeclimate/php-test-reporter": "<=0.3.2",
+                "dhii/php-cs-fixer-config": "dev-php-5.3",
+                "phpunit/phpunit": "^4.8",
+                "ptrofimov/xpmock": "^1.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "RebelCode\\Modular\\Module\\": "src"
+                }
+            },
+            "scripts": {
+                "test": [
+                    "phpunit"
+                ],
+                "csfix": [
+                    "php-cs-fix fix -vvv"
+                ]
+            },
+            "license": [
+                "GPL-3.0"
+            ],
+            "authors": [
+                {
+                    "name": "RebelCode",
+                    "email": "dev@rebelcode.com"
+                }
+            ],
+            "description": "Interfaces for modules.",
+            "support": {
+                "source": "https://github.com/RebelCodecom/module-interface/tree/master",
+                "issues": "https://github.com/RebelCodecom/module-interface/issues"
+            },
+            "time": "2017-06-13 15:18:18"
         }
     ],
     "packages-dev": [
@@ -1683,12 +1776,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "d582eb3f548bb9b975f89d910ac846a197e49123"
+                "reference": "db08b1b2f9adb5d59a5e838d1577e73c418e05ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/d582eb3f548bb9b975f89d910ac846a197e49123",
-                "reference": "d582eb3f548bb9b975f89d910ac846a197e49123",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/db08b1b2f9adb5d59a5e838d1577e73c418e05ed",
+                "reference": "db08b1b2f9adb5d59a5e838d1577e73c418e05ed",
                 "shasum": ""
             },
             "require": {
@@ -1738,7 +1831,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-06 04:51:36"
+            "time": "2017-06-12 16:03:21"
         },
         {
             "name": "symfony/filesystem",
@@ -1844,12 +1937,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937"
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/f29dca382a6485c3cbe6379f0c61230167681937",
-                "reference": "f29dca382a6485c3cbe6379f0c61230167681937",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
+                "reference": "7c8fae0ac1d216eb54349e6a8baa57d515fe8803",
                 "shasum": ""
             },
             "require": {
@@ -1861,7 +1954,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.4-dev"
+                    "dev-master": "1.5-dev"
                 }
             },
             "autoload": {
@@ -1895,7 +1988,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2017-06-09 14:24:12"
+            "time": "2017-06-14 15:44:48"
         },
         {
             "name": "symfony/process",
@@ -2001,12 +2094,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "5f6b55e907b65fdb1cefe25b82604049f1d40e81"
+                "reference": "08c644988dba9d608d18bb8ad8dd633f276137f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/5f6b55e907b65fdb1cefe25b82604049f1d40e81",
-                "reference": "5f6b55e907b65fdb1cefe25b82604049f1d40e81",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/08c644988dba9d608d18bb8ad8dd633f276137f7",
+                "reference": "08c644988dba9d608d18bb8ad8dd633f276137f7",
                 "shasum": ""
             },
             "require": {
@@ -2048,7 +2141,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-06-02 22:30:16"
+            "time": "2017-06-14 20:38:21"
         },
         {
             "name": "webmozart/assert",
@@ -2104,7 +2197,9 @@
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": {
+        "rebelcode/module-interface": 20,
         "dhii/modular-interface": 20,
+        "dhii/collections-abstract-base": 20,
         "dhii/php-cs-fixer-config": 20
     },
     "prefer-stable": false,

--- a/src/AbstractDependencyModuleIterator.php
+++ b/src/AbstractDependencyModuleIterator.php
@@ -3,14 +3,15 @@
 namespace RebelCode\Modular\Iterator;
 
 use ArrayAccess;
+use Dhii\Collection\AbstractTraversableCollection;
 use Dhii\Modular\Module\ModuleInterface;
 
 /**
- * Description of AbstractDependencyModuleIterator.
+ * Basic functionality for a module iterator that handles dependencies.
  *
  * @since [*next-version*]
  */
-abstract class AbstractDependencyModuleIterator extends AbstractModuleIterator
+abstract class AbstractDependencyModuleIterator extends AbstractTraversableCollection
 {
     /**
      * The modules that have already been served, mapped by their keys.
@@ -208,11 +209,11 @@ abstract class AbstractDependencyModuleIterator extends AbstractModuleIterator
      */
     protected function _determineCurrentModule()
     {
-        $module = parent::_determineCurrentModule();
+        $module = parent::_current();
 
-        return is_null($module)
-            ? null
-            : $this->_getDeepMostUnservedModuleDependency($module);
+        return $module instanceof ModuleInterface
+            ? $this->_getDeepMostUnservedModuleDependency($module)
+            : null;
     }
 
     /**
@@ -225,6 +226,7 @@ abstract class AbstractDependencyModuleIterator extends AbstractModuleIterator
         parent::_rewind();
 
         $this->_setServedModules(array());
+        $this->_setCurrent(null);
         $this->_next();
     }
 
@@ -251,7 +253,7 @@ abstract class AbstractDependencyModuleIterator extends AbstractModuleIterator
         }
 
         // Keep advancing until an unserved module is found or until end of module list
-        while ($this->_valid() && $this->_isModuleServed(parent::_determineCurrentModule()->getKey())) {
+        while ($this->_valid() && $this->_isModuleServed(parent::_current()->getKey())) {
             parent::_next();
         }
 

--- a/src/AbstractDependencyModuleIterator.php
+++ b/src/AbstractDependencyModuleIterator.php
@@ -59,10 +59,8 @@ abstract class AbstractDependencyModuleIterator extends AbstractTraversableColle
      */
     protected function _getModuleMap()
     {
-        $items = $this->_getCachedItems();
-
         if (is_null($this->moduleMap)) {
-            $this->moduleMap = $this->_createModuleMap($items);
+            $this->moduleMap = $this->_createModuleMap($this->_getCachedItems());
         }
 
         return $this->moduleMap;

--- a/src/AbstractDependencyModuleIterator.php
+++ b/src/AbstractDependencyModuleIterator.php
@@ -32,6 +32,95 @@ abstract class AbstractDependencyModuleIterator extends AbstractTraversableColle
     protected $current;
 
     /**
+     * A map of the module instances mapped using the module keys.
+     *
+     * @since [*next-version*]
+     *
+     * @var ModuleInterface[]
+     */
+    protected $moduleMap;
+
+    /**
+     * Internal parameterless constructor.
+     *
+     * @since [*next-version*]
+     */
+    protected function _construct()
+    {
+        parent::_construct();
+    }
+
+    /**
+     * Retrieves the map of modules, mapped by their keys.
+     *
+     * @since [*next-version*]
+     *
+     * @return array
+     */
+    protected function _getModuleMap()
+    {
+        $items = $this->_getCachedItems();
+
+        if (is_null($this->moduleMap)) {
+            $this->moduleMap = $this->_createModuleMap($items);
+        }
+
+        return $this->moduleMap;
+    }
+
+    /**
+     * Creates a map of modules, mapped by their keys, from a given module list.
+     *
+     * @since [*next-version*]
+     *
+     * @param array $modules The list of modules.
+     *
+     * @return array The modules, mapped by their keys.
+     */
+    protected function _createModuleMap(array $modules)
+    {
+        $map = array();
+
+        foreach ($modules as $_module) {
+            $map[$_module->getKey()] = $_module;
+        }
+
+        return $map;
+    }
+
+    /**
+     * Clears the map of modules.
+     *
+     * @since [*next-version*]
+     *
+     * @return $this
+     */
+    protected function _clearModuleMap()
+    {
+        $this->moduleMap = null;
+
+        return $this;
+    }
+
+    /**
+     * Retrieves the module with a specific key.
+     *
+     * @since [*next-version*]
+     *
+     * @param string $key The module key.
+     *
+     * @return ModuleInterface|null The module with the given key or null if the module key was not found.
+     */
+    protected function _getModuleByKey($key)
+    {
+        $moduleMap = $this->_getModuleMap();
+
+        return isset($moduleMap[$key])
+            ? $moduleMap[$key]
+            : null;
+    }
+
+    /**
      * Retrieves the list of modules that have already been served.
      *
      * @since [*next-version*]

--- a/test/functional/AbstractDependencyModuleIteratorTest.php
+++ b/test/functional/AbstractDependencyModuleIteratorTest.php
@@ -596,4 +596,48 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $_subject->_next();
         $this->assertNull($_subject->_current());
     }
+
+    /**
+     * Tests the method that retrieve a module by key.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetModuleByKey()
+    {
+        $subject = $this->createInstance();
+
+        $module1 = $this->createModule('one');
+        $module2 = $this->createModule('mod2');
+        $module3 = $this->createModule('third');
+
+        $subject->this()->items = array(
+            'one'   => $module1,
+            'mod2'  => $module2,
+            'third' => $module3
+        );
+
+        $this->assertSame($module2, $subject->this()->_getModuleByKey('mod2'));
+    }
+
+    /**
+     * Tests the method that retrieves a module by key with a non existing key.
+     *
+     * @since [*next-version*]
+     */
+    public function testGetModuleByKeyFail()
+    {
+        $subject = $this->createInstance();
+
+        $module1 = $this->createModule('one');
+        $module2 = $this->createModule('mod2');
+        $module3 = $this->createModule('third');
+
+        $subject->this()->items = array(
+            'one'   => $module1,
+            'mod2'  => $module2,
+            'third' => $module3
+        );
+
+        $this->assertNull($subject->this()->_getModuleByKey('foobar'));
+    }
 }

--- a/test/functional/AbstractDependencyModuleIteratorTest.php
+++ b/test/functional/AbstractDependencyModuleIteratorTest.php
@@ -34,6 +34,8 @@ class AbstractDependencyModuleIteratorTest extends TestCase
             })
             ->new();
 
+        $mock->this()->_construct();
+
         return $mock;
     }
 
@@ -300,16 +302,17 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $subject  = $this->createInstance();
         $_subject = $subject->this();
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne = $this->createModule('one'),
             'two'   => $modTwo = $this->createModule('two', array(
                 'two-dep' => $modTwoDep = $this->createModule('two-dep')
             )),
             'three' => $modThree = $this->createModule('three')
-        ));
+        );
 
-        $_subject->_setIndex(0);
-
+        $_subject->_rewind();
+        
+        $this->assertTrue($_subject->_valid());
         $this->assertSame($modOne, $_subject->_determineCurrentModule());
     }
 
@@ -323,15 +326,17 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $subject  = $this->createInstance();
         $_subject = $subject->this();
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'  => $modOne = $this->createModule('one'),
             'two'  => $modTwo = $this->createModule('two', array(
                 'two-dep' => $modTwoDep = $this->createModule('two-dep')
             )),
             'three' => $modThree = $this->createModule('three')
-        ));
+        );
 
-        $_subject->_setIndex(1);
+        $_subject->_rewind();
+        $_subject->_valid();
+        $_subject->_next();
 
         $this->assertSame($modTwoDep, $_subject->_determineCurrentModule());
     }
@@ -346,15 +351,18 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $subject  = $this->createInstance();
         $_subject = $subject->this();
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne = $this->createModule('one'),
             'two'   => $modTwo = $this->createModule('two', array(
                 'two-dep' => $modTwoDep = $this->createModule('two-dep')
             )),
             'three' => $modThree = $this->createModule('three')
-        ));
+        );
 
-        $_subject->_setIndex(1);
+        $_subject->_rewind();
+        $_subject->_valid();
+        $_subject->_next();
+
         $_subject->_addServedModule($modTwoDep);
 
         $this->assertSame($modTwo, $_subject->_determineCurrentModule());
@@ -370,15 +378,18 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $subject  = $this->createInstance();
         $_subject = $subject->this();
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne = $this->createModule('one'),
             'two'   => $modTwo = $this->createModule('two', array(
                 'two-dep' => $modTwoDep = $this->createModule('two-dep')
             )),
             'three' => $modThree = $this->createModule('three')
-        ));
+        );
 
-        $_subject->_setIndex(1);
+        $_subject->_rewind();
+        $_subject->_valid();
+        $_subject->_next();
+
         $_subject->_addServedModule($modOne);
         $_subject->_addServedModule($modTwoDep);
         $_subject->_addServedModule($modTwo);
@@ -398,23 +409,27 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $subject  = $this->createInstance();
         $_subject = $subject->this();
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne = $this->createModule('one'),
             'two'   => $modTwo = $this->createModule('two'),
             'three' => $modThree = $this->createModule('three')
-        ));
+        );
 
         $_subject->_rewind();
+        $_subject->_valid();
 
         $this->assertSame($modOne, $_subject->_current());
 
         $_subject->_next();
+        $_subject->_valid();
         $this->assertSame($modTwo, $_subject->_current());
 
         $_subject->_next();
+        $_subject->_valid();
         $this->assertSame($modThree, $_subject->_current());
 
         $_subject->_next();
+        $_subject->_valid();
         $this->assertNull($_subject->_current());
     }
 
@@ -430,25 +445,29 @@ class AbstractDependencyModuleIteratorTest extends TestCase
 
         $modThree = $this->createModule('three');
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne = $this->createModule('one'),
             'two'   => $modTwo = $this->createModule('two', array(
                 'three' => $modThree
             )),
             'three' => $modThree
-        ));
+        );
 
         $_subject->_rewind();
+        $_subject->_valid();
 
         $this->assertSame($modOne, $_subject->_current());
 
         $_subject->_next();
+        $_subject->_valid();
         $this->assertSame($modThree, $_subject->_current());
 
         $_subject->_next();
+        $_subject->_valid();
         $this->assertSame($modTwo, $_subject->_current());
 
         $_subject->_next();
+        $_subject->_valid();
         $this->assertNull($_subject->_current());
     }
 
@@ -468,14 +487,14 @@ class AbstractDependencyModuleIteratorTest extends TestCase
             'four' => $modFour
         ));
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne = $this->createModule('one'),
             'two'   => $modTwo = $this->createModule('two', array(
                 'three' => $modThree
             )),
             'three' => $modThree,
             'four'  => $modFour
-        ));
+        );
 
         $_subject->_rewind();
 
@@ -508,7 +527,7 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $modThree = $this->createModule('three');
         $modFour  = $this->createModule('four');
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne = $this->createModule('one'),
             'two'   => $modTwo = $this->createModule('two', array(
                 'three' => $modThree,
@@ -516,7 +535,7 @@ class AbstractDependencyModuleIteratorTest extends TestCase
             )),
             'three' => $modThree,
             'four'  => $modFour
-        ));
+        );
 
         $_subject->_rewind();
         $_subject->_current();
@@ -550,7 +569,7 @@ class AbstractDependencyModuleIteratorTest extends TestCase
         $modOne = $this->createModule('one');
         $modTwo = $this->createModule('two');
 
-        $_subject->_setModules(array(
+        $_subject->items = array(
             'one'   => $modOne,
             'two'   => $modTwo,
             'three' => $modThree = $this->createModule('three', array(
@@ -558,7 +577,7 @@ class AbstractDependencyModuleIteratorTest extends TestCase
                 'two' => $modTwo,
             )),
             'four'  => $modFour = $this->createModule('four')
-        ));
+        );
 
         $_subject->_rewind();
         $_subject->_current();


### PR DESCRIPTION
Changes that make the [`AbstractDependencyModuleIterator`] now extend off of [`AbstractTraversableCollection`].

[`AbstractDependencyModuleIterator`]: https://github.com/RebelCodecom/module-iterator-abstract/blob/task/use-collection-iterator/src/AbstractDependencyModuleIterator.php
[`AbstractTraversableCollection`]: https://github.com/Dhii/collections-abstract-base/blob/wip/refactor/test/functional/AbstractTraversableCollectionTest.php#L66